### PR TITLE
Add note about NuSystem demos available via apt

### DIFF
--- a/n64hbrew/modernsdk/startoff.html
+++ b/n64hbrew/modernsdk/startoff.html
@@ -131,6 +131,15 @@
     After you make the demo, you can run the resulting <code>.z64</code> in the emulator/flashcart of your choice, and it should work perfectly!
 </p>
 
+<h3>NuSystem demos</h3>
+<p>
+    The NuSystem demos can also be installed via APT:<br>
+    <br>
+    <code>sudo apt install nusys-demos</code><br>
+    <br>
+    They can then be found at <code>/usr/src/PR/nusys</code>. Like the regular demos, it's best to copy them to another directory before compiling.
+</p>
+
 <a href="index.html">Back home</a>
 </body>
 </html>


### PR DESCRIPTION
This change adds an extra note about installing `nusys-demos`.

![image](https://user-images.githubusercontent.com/1205433/113222378-c1f95200-923b-11eb-9dae-1a731a2f31c7.png)

